### PR TITLE
FAPI-4 ci test exec

### DIFF
--- a/pretest.sh
+++ b/pretest.sh
@@ -11,9 +11,13 @@ export SQLALCHEMY_SILENCE_UBER_WARNING=1
 
 cd ../../
 poetry run pytest
+test_result=$?
 
 # cleanup
 cd ./tests/config
 rm -rf ./alembic
 rm ./alembic.ini
 rm ./test.db
+
+echo "Test result: $test_result"
+exit $test_result

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -1,6 +1,10 @@
 from app.crud.base import CRUDBase
 
 
+def validate_ci_testing_failure():
+    assert 1 == 2
+
+
 def test_root_endpoint(client):
     response = client.get("/")
     assert response.status_code == 200

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -1,7 +1,7 @@
 from app.crud.base import CRUDBase
 
 
-def validate_ci_testing_failure():
+def test_ci_failure():
     assert 1 == 2
 
 

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -1,10 +1,6 @@
 from app.crud.base import CRUDBase
 
 
-def test_ci_failure():
-    assert 1 == 2
-
-
 def test_root_endpoint(client):
     response = client.get("/")
     assert response.status_code == 200


### PR DESCRIPTION
Validating that pipeline stops execution if any test case fails

Updated the test shell script wrapper to capture the return code of `poetry run pytest` and return that value